### PR TITLE
Proper urls for patch-6788/1.9.2.2, also seperated the ACL for issue #10

### DIFF
--- a/app/code/community/Icepay/IceAdvanced/Block/Adminhtml/Grid/Paymentmethods.php
+++ b/app/code/community/Icepay/IceAdvanced/Block/Adminhtml/Grid/Paymentmethods.php
@@ -25,9 +25,9 @@ class Icepay_IceAdvanced_Block_Adminhtml_Grid_PaymentMethods extends Mage_Adminh
     public function __construct()
     {
         $this->_scope = Mage::app()->getStore(Mage::helper("icecore")->getStoreFromRequest())->getId();
-        $this->_ajaxLoadPaymentMethodURL = Mage::helper('adminhtml')->getUrl('icepayadvanced/config/index/paymentmethod/{{pm_code}}', array('_secure' => true, 'scope' => $this->_scope));
-        $this->_ajaxSavePaymentMethodURL = Mage::helper('adminhtml')->getUrl('icepayadvanced/ajax/save_paymentmethod', array('_secure' => true, 'scope' => $this->_scope));
-        $this->_ajaxGetPaymentMethodsURL = Mage::helper('adminhtml')->getUrl('icepayadvanced/ajax/get_paymentmethods', array('_secure' => true));
+        $this->_ajaxLoadPaymentMethodURL = Mage::helper('adminhtml')->getUrl('adminhtml/iceadvanced_config/index/paymentmethod/{{pm_code}}', array('_secure' => true, 'scope' => $this->_scope));
+        $this->_ajaxSavePaymentMethodURL = Mage::helper('adminhtml')->getUrl('adminhtml/iceadvanced_ajax/save_paymentmethod', array('_secure' => true, 'scope' => $this->_scope));
+        $this->_ajaxGetPaymentMethodsURL = Mage::helper('adminhtml')->getUrl('adminhtml/iceadvanced_ajax/get_paymentmethods', array('_secure' => true));
 
         $this->setTemplate('icepayadvanced/grid_paymentmethods.phtml');
     }

--- a/app/code/community/Icepay/IceAdvanced/controllers/Adminhtml/Iceadvanced/AjaxController.php
+++ b/app/code/community/Icepay/IceAdvanced/controllers/Adminhtml/Iceadvanced/AjaxController.php
@@ -13,9 +13,8 @@
  *  charged in accordance with the standard ICEPAY tariffs.
  * 
  */
-class Icepay_IceAdvanced_AjaxController extends Mage_Adminhtml_Controller_Action
+class Icepay_IceAdvanced_Adminhtml_Iceadvanced_AjaxController extends Mage_Adminhtml_Controller_Action
 {
-
     protected $webservice = null;
 
     public function iceWebservice()

--- a/app/code/community/Icepay/IceAdvanced/controllers/Adminhtml/Iceadvanced/ConfigController.php
+++ b/app/code/community/Icepay/IceAdvanced/controllers/Adminhtml/Iceadvanced/ConfigController.php
@@ -14,7 +14,7 @@
  * 
  */
 
-class Icepay_IceAdvanced_ConfigController extends Mage_Adminhtml_Controller_Action {
+class Icepay_IceAdvanced_Adminhtml_Iceadvanced_ConfigController extends Mage_Adminhtml_Controller_Action {
 
 
     /**

--- a/app/code/community/Icepay/IceAdvanced/etc/adminhtml.xml
+++ b/app/code/community/Icepay/IceAdvanced/etc/adminhtml.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<config>
+    <acl>
+        <resources>
+            <admin>
+                <children>
+                    <system>
+                        <children>
+                            <config>
+                                <children>
+                                    <iceadvanced translate="title" module="iceadvanced">
+                                        <title>iceadvanced Settings</title>
+                                    </iceadvanced>
+                                </children>
+                            </config>
+                        </children>
+                    </system>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>

--- a/app/code/community/Icepay/IceAdvanced/etc/config.xml
+++ b/app/code/community/Icepay/IceAdvanced/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Icepay_IceAdvanced>
-            <version>1.2.10</version>
+            <version>1.2.11</version>
         </Icepay_IceAdvanced>
     </modules>
     <frontend>
@@ -146,37 +146,17 @@
                 </Icepay_IceAdvanced>
             </modules>
         </translate>
-
-        <acl>
-            <resources>
-                <admin>
-                    <children>
-                        <system>
-                            <children>
-                                <config>
-                                    <children>
-                                        <iceadvanced translate="title" module="iceadvanced">
-                                            <title>iceadvanced Settings</title>
-                                        </iceadvanced>
-                                    </children>
-                                </config>
-                            </children>
-                        </system>
-                    </children>
-                </admin>
-            </resources>
-        </acl>
     </adminhtml>
 
     <admin>
         <routers>
-            <iceadvanced>
-                <use>admin</use>
+            <adminhtml>
                 <args>
-                    <module>Icepay_IceAdvanced</module>
-                    <frontName>icepayadvanced</frontName>
+                    <modules>
+                        <icepay_iceadvanced after="Mage_Adminhtml">Icepay_IceAdvanced_Adminhtml</icepay_iceadvanced>
+                    </modules>
                 </args>
-            </iceadvanced>
+            </adminhtml>
         </routers>
     </admin>
 </config>


### PR DESCRIPTION
This fixes the icepay module for magento 1.9.2.2 since using your own admin environment url is not longer allowed. See issue #10 for info about the patch